### PR TITLE
Adding a how-to for starting a development server for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Source code of the website of the [INOSC Starter Kit](https://osf.io/7vez3/). De
 
 ## How to start a development server
 
-First, Install [Hugo](https://gohugo.io/installation/)
+First, install [Hugo](https://gohugo.io/installation/).
 
 Then, start a development server:
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,20 @@
 
 Source code of the website of the [INOSC Starter Kit](https://osf.io/7vez3/). Developed with [Hugo](https://themes.gohugo.io/) and [VSCodium](https://vscodium.com/). Published with [Wowchemy](https://wowchemy.com/), deployed with [Netlify](https://www.netlify.com/). French translation by [Antoine Blanchard](https://github.com/Enro) and [Candice Fillaud](https://github.com/CFillaud). Portuguese translation by [Denise Capela dos Santos](https://pt.linkedin.com/in/denise-capela-dos-santos-542b6828)
 
-***
+---
 
 ![INOSC logo](./static/media/INOSC_logo.jpg)
 
-***
+---
+
+## How to start a development server
+
+First, Install [Hugo](https://gohugo.io/installation/)
+
+Then, start a development server:
+
+```bash
+hugo serve
+```
+
+You can access the site at http://localhost:1313/

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 Source code of the website of the [INOSC Starter Kit](https://osf.io/7vez3/). Developed with [Hugo](https://themes.gohugo.io/) and [VSCodium](https://vscodium.com/). Published with [Wowchemy](https://wowchemy.com/), deployed with [Netlify](https://www.netlify.com/). French translation by [Antoine Blanchard](https://github.com/Enro) and [Candice Fillaud](https://github.com/CFillaud). Portuguese translation by [Denise Capela dos Santos](https://pt.linkedin.com/in/denise-capela-dos-santos-542b6828)
 
----
+***
 
 ![INOSC logo](./static/media/INOSC_logo.jpg)
 
----
+***
 
 ## How to start a development server
 


### PR DESCRIPTION
Hello! I noticed that there's no instruction for starting a development server, so I'm suggesting to add one in the README file. 🤞
